### PR TITLE
Change shebangs and python calls to call python2

### DIFF
--- a/server/bin/deskcon-server-settings
+++ b/server/bin/deskcon-server-settings
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd /usr/share/deskcon-server/
-python "settingswindow.py" $@
+python2 "settingswindow.py" $@

--- a/server/deskcon-server
+++ b/server/deskcon-server
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # DesCon Desktop Server
 # Version 0.2
 

--- a/server/filechooser.py
+++ b/server/filechooser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 import os
 import sys
 import socket

--- a/server/fingerprints.py
+++ b/server/fingerprints.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import sys
 import configmanager

--- a/server/pair.py
+++ b/server/pair.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import socket
 import SocketServer

--- a/server/ping.py
+++ b/server/ping.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/server/settingswindow.py
+++ b/server/settingswindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/server/setupdevice.py
+++ b/server/setupdevice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/server/sms.py
+++ b/server/sms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/server/windows.py
+++ b/server/windows.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 import threading
 import os
 import sys


### PR DESCRIPTION
Change all python calls to python2, to ensure correct version is used, as deskcon-server currently is python2 only (I'm still working on python3 support, but I currently don't have much time).
cf. [PEP-394](http://legacy.python.org/dev/peps/pep-0394/)

Kind Regards
