### PR TITLE
Adding autostart desktop file

### DIFF
--- a/gnome/autostart/deskcon.desktop
+++ b/gnome/autostart/deskcon.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Deskcon
+Comment=Sync notifications between your phone and GNOME desktop
+Exec=/usr/bin/deskcon-server
+X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
Adding an autostart desktop file so the deskcon server will be started automatically when a user logs into their GNOME desktop.
